### PR TITLE
Change whitelist to allowlist

### DIFF
--- a/index.md
+++ b/index.md
@@ -59,7 +59,7 @@ Here is a sneak peek of the 2019 version:
 * **API6:2019 Mass Assignment**
 
   Binding client provided data (e.g., JSON) to data models, without proper
-  properties filtering based on a whitelist, usually lead to Mass Assignment.
+  properties filtering based on an allowlist, usually lead to Mass Assignment.
   Either guessing objects properties, exploring other API endpoints, reading the
   documentation, or providing additional object properties in request payloads,
   allows attackers to modify object properties they are not supposed to.

--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ Here is a sneak peek of the 2019 version:
   Authentication mechanisms are often implemented incorrectly, allowing
   attackers to compromise authentication tokens or to exploit implementation
   flaws to assume other user's identities temporarily or permanently.
-  Compromising system's ability to identify the client/user, compromises API
+  Compromising a system's ability to identify the client/user, compromises API
   security overall.
 * **API3:2019 Excessive Data Exposure**
 
@@ -59,7 +59,7 @@ Here is a sneak peek of the 2019 version:
 * **API6:2019 Mass Assignment**
 
   Binding client provided data (e.g., JSON) to data models, without proper
-  properties filtering based on an allowlist, usually lead to Mass Assignment.
+  properties filtering based on an allowlist, usually leads to Mass Assignment.
   Either guessing objects properties, exploring other API endpoints, reading the
   documentation, or providing additional object properties in request payloads,
   allows attackers to modify object properties they are not supposed to.


### PR DESCRIPTION
Thanks for a wonderful security resource.

This Pull Request changes the term `whitelist` to `allowlist` in order to be more explicit and inclusive. See https://github.com/rails/rails/issues/33677 and https://gitlab.com/gitlab-org/gitlab/-/issues/7554 for other similar efforts in the community.

I realise that the terms `whitelist` and `blacklist` are used elsewhere on the OWASP site (e.g. https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html#whitelisting-vs-blacklisting) so if this was a change the OWASP community wanted to make we may need to take a look at what else could be updated?

I've also spotted and fixed two small grammatical issues.