### PR TITLE
Add pitch for OWASP listing

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,6 +5,10 @@ title: OWASP API Security Project
 tags: api security top10 translations acknowledgments join roadmap news
 level: 3
 type: documentation
+pitch: >
+  The API Security project focuses on strategies and solutions to understand
+  and mitigate the unique vulnerabilities and security risks of Application
+  Programming Interfaces (APIs)
 
 ---
 


### PR DESCRIPTION
This will provide the needed text for the entry in https://owasp.org/projects/
At present the page shows only the placeholder:
<img width="436" height="266" alt="Screenshot 2025-10-13 at 20 52 14" src="https://github.com/user-attachments/assets/3eff1d8d-8b5f-4d4d-9d3a-1f7c7536ee70" />

This closes #9 